### PR TITLE
fixing NaT handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Scripts/database/*up.sql
 *.cpython-310.pyc 
 Notebooks/1_Initialize_Database/City_Comparisons/*
 Scripts/python/test.txt
+__pycache__

--- a/Scripts/python/Daily_Updates.py
+++ b/Scripts/python/Daily_Updates.py
@@ -16,6 +16,7 @@ import psycopg2
 
 import pandas as pd
 import geopandas as gpd
+import numpy as np
 
 # Load our functions
 
@@ -103,7 +104,6 @@ def Sensor_Information_Daily_Update(pg_connection_dict, purpleAir_api):
     merged_df['channel_flags_SpikeAlerts'] = merged_df.channel_flags_SpikeAlerts.astype("Int64")
     
     # Sort the sensors
-    
     sensors_dict = Sort_Sensors(merged_df) # A dictionary of lists of sensor_indices - categories/keys: 'Same Names', 'New', 'Expired', 'Conflicting Names', 'New Flags'
     
     if len(sensors_dict['New']): # Add new sensors to our database (another PurpleAir api call)
@@ -175,9 +175,9 @@ def Sort_Sensors(merged_df):
     # Does PurpleAir not have the name?
     no_name_PurpleAir = (merged_df.name_PurpleAir.isna())
     # We haven't seen recently? - within 30 days
-    not_seen_recently = (merged_df.last_seen_SpikeAlerts.dt.date <
-                            (dt.datetime.now(pytz.timezone('America/Chicago')
-                            ) - dt.timedelta(days = 30)).date())
+    not_seen_recently = (merged_df.last_seen_SpikeAlerts <
+                            np.datetime64((dt.datetime.now(pytz.timezone('America/Chicago')
+                            ) - dt.timedelta(days = 30))))
     # Good channel State
     good_channel_state = (merged_df.channel_state != 0)
     # New Flags (within past day) - a 4 in our database


### PR DESCRIPTION
This is a small change but please check it works on your end (I'm pretty sure our DBs are all same types, etc. but it's time columns, probably best to check).

When I was looking into the branch, I had nothing in the sensor table, which mean the _SpikeAlerts suffixes were all NAs, including NaT for last_seen_SpikeAlerts. This NaT was having issues with the not_seen_recently comparison -- weirdly it looks as if NaT cast to Date wasn't comparing correctly. 

I this would be encountered when a sensor was added as well, so made sense to try and get a solution instead of just doing some mockup initialization stuff.

When I left it as a timestamp it also wasn't comparing correctly (np.datetime64 vs datetime). assumed that the date cast was to make it compare right, and not because we are especially concerned with removing the timestamp. I did some reading and decided it was probably best to cast the today-30 calculation to numpy/datetime64 -- now it worked well for me on the first initialization and future runs. I didn't mock up an _expired_ sensor, but it's the same comparison so I don't think it'd be an issue. 